### PR TITLE
crdroid: Fix typo in device maintainers

### DIFF
--- a/res/xml/device_maintainers.xml
+++ b/res/xml/device_maintainers.xml
@@ -498,7 +498,7 @@
          
         <Preference
             android:id="@+id/device_wingtech_wt88047"
-            android:icon="@drwable/phone_tint"
+            android:icon="@drawable/phone_tint"
             android:title="@string/device_wingtech_wt88047"
             android:summary="@string/device_wingtech_wt88047_summary"
             android:selectable="false" />


### PR DESCRIPTION
packages/apps/crDroidSettings/res/xml/device_maintainers.xml:499: error: Error: No resource found that matches the given name (at 'icon' with value '@drwable/phone_tint').