### PR TITLE
chinese translations: Remove duplicate string

### DIFF
--- a/res/values-zh-rCN/cr_strings.xml
+++ b/res/values-zh-rCN/cr_strings.xml
@@ -278,7 +278,6 @@
     <!-- Pie -->
     <string name="pie_enable_title">启用Pie控制</string>
     <string name="pie_settings">Pie设置</string>
-    <string name="pie_enable_title">启用Pie控制</string>
     <string name="pie_settings_summary">调整Pie到您喜欢的程度</string>
     <string name="pie_theme_mode_title">主题</string>
     <string name="pie_auto">自动</string>


### PR DESCRIPTION
packages/apps/crDroidSettings/res/values-zh-rCN/cr_strings.xml:281: error: duplicate value for resource 'string/pie_enable_title' with config 'zh-rCN'.
packages/apps/crDroidSettings/res/values-zh-rCN/cr_strings.xml:279: error: resource previously defined here.