### PR TITLE
Add setting for less frequent notification sounds [2/2]

### DIFF
--- a/res/xml/crdroid_settings_sound.xml
+++ b/res/xml/crdroid_settings_sound.xml
@@ -48,15 +48,15 @@
         android:summary="@string/audio_panel_view_summary"
         android:fragment="com.crdroid.settings.fragments.sound.VolumePanel" />
 
-    <!-- Less Notification sounds
-    <ListPreference
-        android:key="less_notification_sounds"
+    <!-- Less Notification sounds -->
+    <com.crdroid.settings.preferences.SystemSettingListPreference
+        android:key="mute_annoying_notifications_threshold"
         android:icon="@drawable/ic_headsup"
         android:title="@string/less_notification_sounds_title"
         android:summary="@string/less_notification_sounds_summary"
         android:entries="@array/less_notification_sounds_entries"
         android:entryValues="@array/less_notification_sounds_values"
-        android:persistent="false" /> -->
+        android:defaultValue="30000" />
 
     <!-- Launch music player when headset is connected
     <cyanogenmod.preference.CMSystemSettingSwitchPreference


### PR DESCRIPTION
Not sure about the default value, used 30 seconds as that was the default in the patches in the other repository. Ref: [[1/2]]

[1/2]: https://github.com/crdroidandroid/android_frameworks_base/pull/258