### PR TITLE
GamingMode: Add ADB toggle [2/2]

### DIFF
--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -2386,6 +2386,8 @@
     <string name="gaming_mode_headsup_summary">Calls and alarms are exempted</string>
     <string name="gaming_mode_hardware_keys_title">Lock buttons</string>
     <string name="gaming_mode_hardware_keys_summary">When Gaming mode is turned on, buttons will be locked</string>
+    <string name="gaming_mode_adb_title">Disable USB debugging</string>
+    <string name="gaming_mode_adb_summary">Disable USB debugging when Gaming mode is turned on</string>
     <string name="gaming_mode_brightness_title">Disable automatic brightness</string>
     <string name="gaming_mode_brightness_summary">Lock screen brightness when Gaming mode is turned on</string>
     <string name="gaming_mode_ringer_title">Ringer in Gaming mode</string>

--- a/res/xml/gaming_mode_settings.xml
+++ b/res/xml/gaming_mode_settings.xml
@@ -42,6 +42,14 @@
         android:dependency="gaming_mode_enabled"
         android:defaultValue="false" />
 
+    <!-- ADB -->
+    <com.crdroid.settings.preferences.SystemSettingSwitchPreference
+        android:key="gaming_mode_adb_toggle"
+        android:title="@string/gaming_mode_adb_title"
+        android:summary="@string/gaming_mode_adb_summary"
+        android:dependency="gaming_mode_enabled"
+        android:defaultValue="false" />
+
     <!-- Manual brightness -->
     <com.crdroid.settings.preferences.SystemSettingSwitchPreference
         android:key="gaming_mode_manual_brightness_toggle"

--- a/src/com/crdroid/settings/fragments/misc/GamingMode.java
+++ b/src/com/crdroid/settings/fragments/misc/GamingMode.java
@@ -204,6 +204,8 @@ public class GamingMode extends SettingsPreferenceFragment
         Settings.System.putIntForUser(resolver,
                 Settings.System.GAMING_MODE_HW_KEYS_TOGGLE, 0, UserHandle.USER_CURRENT);
         Settings.System.putIntForUser(resolver,
+                Settings.System.GAMING_MODE_ADB_TOGGLE, 0, UserHandle.USER_CURRENT);
+        Settings.System.putIntForUser(resolver,
                 Settings.System.GAMING_MODE_HEADSUP_TOGGLE, 1, UserHandle.USER_CURRENT);
         Settings.System.putIntForUser(resolver,
                 Settings.System.GAMING_MODE_RINGER_MODE, 0, UserHandle.USER_CURRENT);


### PR DESCRIPTION
Unfortunately, some games are prevented from launching when USB debugging is enabled.
Add a toggle to temporarily turn off USB debugging so that happy debugging and gameplay can be compatible.
https://github.com/crdroidandroid/android_frameworks_base/pull/706