### PR TITLE
Fix the typo in CR strings

### DIFF
--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -699,9 +699,9 @@
 
     <!-- Privacy Indicator -->
     <string name="mic_camera_privacy_indicator_title">Mic and camera privacy indicator</string>
-    <string name="mic_camera_privacy_indicator_summary">Show separate indicator when an any app uses mic or camera</string>
+    <string name="mic_camera_privacy_indicator_summary">Show separate indicator when any app uses mic or camera</string>
     <string name="location_privacy_indicator_title">Location privacy indicator</string>
-    <string name="location_privacy_indicator_summary">Show separate indicator when an any app uses location</string>
+    <string name="location_privacy_indicator_summary">Show separate indicator when any app uses location</string>
 
     <!-- Deep Sleep percentage in device info -->
     <string name="status_sleep_time">Deep sleep</string>


### PR DESCRIPTION
Fix the typo for mic_camera_privacy_indicator_summary and location_privacy_indicator_summary