### PR TITLE
crdroid: Set "Screen Off UDFPS" off by default [2/2]

### DIFF
--- a/res/xml/udfps_settings.xml
+++ b/res/xml/udfps_settings.xml
@@ -37,6 +37,6 @@
         android:key="screen_off_udfps"
         android:title="@string/screen_off_udfps_title"
         android:summary="@string/screen_off_udfps_summary"
-        android:persistent="true" />
+        android:defaultValue="false" />
 
 </PreferenceScreen>

--- a/src/com/crdroid/settings/fragments/lockscreen/UdfpsSettings.java
+++ b/src/com/crdroid/settings/fragments/lockscreen/UdfpsSettings.java
@@ -82,7 +82,7 @@ public class UdfpsSettings extends SettingsPreferenceFragment {
         Settings.System.putIntForUser(resolver,
                 Settings.System.UDFPS_ICON, 0, UserHandle.USER_CURRENT);
         Settings.System.putIntForUser(resolver,
-                Settings.System.SCREEN_OFF_UDFPS, 1, UserHandle.USER_CURRENT);
+                Settings.System.SCREEN_OFF_UDFPS, 0, UserHandle.USER_CURRENT);
     }
 
     @Override


### PR DESCRIPTION
 1) Significantly reduced battery drain
 2) Let the user decide if he needs it?

Change-Id: I91e0798c53efff0efbdf9976a20aedecb0d18d80