### PR TITLE
crdroid: Move hardcoded sensor-based Doze calibration timings to overlay

### DIFF
--- a/res/values/cr_config.xml
+++ b/res/values/cr_config.xml
@@ -30,4 +30,43 @@
              relative to the natural orientation of the display
              (true for some tablets) -->
     <integer name="config_volumeRockerVsDisplayOrientation">1</integer>
+
+    <!-- Minimum interval (in milliseconds) needed to trigger doze pulsing
+         on "Pickup up" gesture.
+         Default: 2500 milliseconds (2.5 seconds * 1000) -->
+    <integer name="config_dozePulsePickup_MinPulseIntervalMs">2500</integer>
+
+    <!-- Timeout interval (in milliseconds) needed to wake up the screen
+         after "Pickup up" gesture is triggered.
+         Default: 300 milliseconds -->
+    <integer name="config_dozePulsePickup_WakelockTimeoutMs">300</integer>
+
+    <!-- Maximum time (in nanoseconds) for the hand to cover the proximity sensor
+         to trigger doze pulsing on "Hand wave" gesture.
+         Default: 1000000000 nanoseconds (1 second * 1000 * 1000 * 1000) -->
+    <integer name="config_dozePulseProximity_HandwaveMaxDeltaNs">1000000000</integer>
+
+    <!-- Minimum time (in nanoseconds) until the device is considered to have been
+         in the pocket.
+         Default: 2000000000 nanoseconds (2 seconds * 1000 * 1000 * 1000) -->
+    <integer name="config_dozePulseProximity_PocketMinDeltaNs">2000000000</integer>
+
+    <!-- Timeout interval (in milliseconds) needed to wake up the screen
+         after "Hand wave" gesture is triggered.
+         Default: 300 milliseconds -->
+    <integer name="config_dozePulseProximity_WakelockTimeoutMs">300</integer>
+
+    <!-- The tilt sensor rate (in milliseconds) events are delivered at.
+         Default: 100 milliseconds -->
+    <integer name="config_dozePulseTilt_BatchLatencyInMs">100</integer>
+
+    <!-- Minimum interval (in milliseconds) needed to trigger doze pulsing
+         on "Tilt" gesture.
+         Default: 2500 milliseconds (2.5 seconds * 1000) -->
+    <integer name="config_dozePulseTilt_MinPulseIntervalMs">2500</integer>
+
+    <!-- Timeout interval (in milliseconds) needed to wake up the screen
+         after "Tilt" gesture is triggered.
+         Default: 300 milliseconds -->
+    <integer name="config_dozePulseTilt_WakelockTimeoutMs">300</integer>
 </resources>

--- a/src/com/crdroid/settings/fragments/ui/doze/PickupSensor.java
+++ b/src/com/crdroid/settings/fragments/ui/doze/PickupSensor.java
@@ -17,6 +17,7 @@
 package com.crdroid.settings.fragments.ui.doze;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -42,9 +43,6 @@ public class PickupSensor implements SensorEventListener {
     private static final boolean DEBUG = false;
     private static final String TAG = "PickupSensor";
 
-    private static final int MIN_PULSE_INTERVAL_MS = 2500;
-    private static final int WAKELOCK_TIMEOUT_MS = 300;
-
     private SensorManager mSensorManager;
     private Sensor mSensorPickup;
     private Context mContext;
@@ -54,6 +52,8 @@ public class PickupSensor implements SensorEventListener {
     private WakeLock mWakeLock;
 
     private boolean mIsCustomPickupSensor;
+    private int mMinPulseIntervalMs;
+    private int mWakelockTimeoutMs;
 
     private float[] mGravity;
     private float mAccelLast;
@@ -64,8 +64,9 @@ public class PickupSensor implements SensorEventListener {
 
     public PickupSensor(Context context) {
         mContext = context;
+        final Resources res = context.getResources();
         mSensorManager = mContext.getSystemService(SensorManager.class);
-        final String pickup_sensor = context.getResources().getString(R.string.pickup_sensor);
+        final String pickup_sensor = res.getString(R.string.pickup_sensor);
         mIsCustomPickupSensor = pickup_sensor != null && !pickup_sensor.isEmpty();
         if (mIsCustomPickupSensor) {
             for (Sensor sensor : mSensorManager.getSensorList(Sensor.TYPE_ALL)) {
@@ -77,7 +78,15 @@ public class PickupSensor implements SensorEventListener {
         } else {
             mSensorPickup = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         }
-        if (DEBUG) Log.d(TAG, "Pickup sensor: " + mSensorPickup.getStringType());
+        mMinPulseIntervalMs =
+            res.getInteger(R.integer.config_dozePulsePickup_MinPulseIntervalMs);
+        mWakelockTimeoutMs =
+            res.getInteger(R.integer.config_dozePulsePickup_WakelockTimeoutMs);
+        if (DEBUG) {
+            Log.d(TAG, "Pickup sensor: " + mSensorPickup.getStringType());
+            Log.d(TAG, "MinPulseIntervalMs: " + String.valueOf(mMinPulseIntervalMs));
+            Log.d(TAG, "WakelockTimeoutMs: " + String.valueOf(mWakelockTimeoutMs));
+        }
         telephonyManager = (TelephonyManager) mContext.getSystemService(Context.TELEPHONY_SERVICE);
         mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
         mWakeLock = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
@@ -99,7 +108,7 @@ public class PickupSensor implements SensorEventListener {
         if (DEBUG) Log.d(TAG, "Got sensor event: " + event.values[0]);
 
         long delta = SystemClock.elapsedRealtime() - mEntryTimestamp;
-        if (delta < MIN_PULSE_INTERVAL_MS) {
+        if (delta < mMinPulseIntervalMs) {
             return;
         } else {
             mEntryTimestamp = SystemClock.elapsedRealtime();
@@ -133,7 +142,7 @@ public class PickupSensor implements SensorEventListener {
     private void launchWakeOrPulse() {
         boolean isRaiseToWake = Utils.isRaiseToWakeEnabled(mContext);
         if (isRaiseToWake) {
-            mWakeLock.acquire(WAKELOCK_TIMEOUT_MS);
+            mWakeLock.acquire(mWakelockTimeoutMs);
             mPowerManager.wakeUp(SystemClock.uptimeMillis(),
                 PowerManager.WAKE_REASON_GESTURE, TAG);
         } else {

--- a/src/com/crdroid/settings/fragments/ui/doze/ProximitySensor.java
+++ b/src/com/crdroid/settings/fragments/ui/doze/ProximitySensor.java
@@ -17,6 +17,7 @@
 package com.crdroid.settings.fragments.ui.doze;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -30,6 +31,8 @@ import android.os.Vibrator;
 import android.provider.Settings;
 import android.util.Log;
 
+import com.android.settings.R;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -38,14 +41,6 @@ public class ProximitySensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
     private static final String TAG = "ProximitySensor";
-
-    private static final int WAKELOCK_TIMEOUT_MS = 300;
-
-    // Maximum time for the hand to cover the sensor: 1s
-    private static final int HANDWAVE_MAX_DELTA_NS = 1000 * 1000 * 1000;
-
-    // Minimum time until the device is considered to have been in the pocket: 2s
-    private static final int POCKET_MIN_DELTA_NS = 2000 * 1000 * 1000;
 
     private SensorManager mSensorManager;
     private Sensor mSensor;
@@ -56,14 +51,30 @@ public class ProximitySensor implements SensorEventListener {
 
     private boolean mSawNear = false;
     private long mInPocketTime = 0;
+    private int mWakelockTimeoutMs;
+    private int mHandWaveMaxDeltaNs;
+    private int mPocketMinDeltaNs;
 
     private Vibrator mVibrator;
 
     public ProximitySensor(Context context) {
         mContext = context;
+        final Resources res = context.getResources();
         mSensorManager = mContext.getSystemService(SensorManager.class);
-        final boolean wakeup = context.getResources().getBoolean(com.android.internal.R.bool.config_deviceHaveWakeUpProximity);
+        final boolean wakeup =
+            res.getBoolean(com.android.internal.R.bool.config_deviceHaveWakeUpProximity);
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY, wakeup);
+        mWakelockTimeoutMs =
+            res.getInteger(R.integer.config_dozePulseProximity_WakelockTimeoutMs);
+        mHandWaveMaxDeltaNs =
+            res.getInteger(R.integer.config_dozePulseProximity_HandwaveMaxDeltaNs);
+        mPocketMinDeltaNs =
+            res.getInteger(R.integer.config_dozePulseProximity_PocketMinDeltaNs);
+        if (DEBUG) {
+            Log.d(TAG, "WakelockTimeoutMs: " + String.valueOf(mWakelockTimeoutMs));
+            Log.d(TAG, "HandwaveMaxDeltaNs: " + String.valueOf(mHandWaveMaxDeltaNs));
+            Log.d(TAG, "PocketMinDeltaNs: " + String.valueOf(mPocketMinDeltaNs));
+        }
         mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
         mWakeLock = mPowerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
         mExecutorService = Executors.newSingleThreadExecutor();
@@ -84,7 +95,7 @@ public class ProximitySensor implements SensorEventListener {
         if (mSawNear && !isNear) {
             if (shouldPulse(event.timestamp)) {
                 if (isRaiseToWake) {
-                    mWakeLock.acquire(WAKELOCK_TIMEOUT_MS);
+                    mWakeLock.acquire(mWakelockTimeoutMs);
                     mPowerManager.wakeUp(SystemClock.uptimeMillis(),
                         PowerManager.WAKE_REASON_GESTURE, TAG);
                 } else {
@@ -102,9 +113,9 @@ public class ProximitySensor implements SensorEventListener {
         long delta = timestamp - mInPocketTime;
 
         if (Utils.handwaveGestureEnabled(mContext)) {
-            return delta < HANDWAVE_MAX_DELTA_NS;
+            return delta < mHandWaveMaxDeltaNs;
         } else if (Utils.pocketGestureEnabled(mContext)) {
-            return delta >= POCKET_MIN_DELTA_NS;
+            return delta >= mPocketMinDeltaNs;
         }
         return false;
     }


### PR DESCRIPTION
1. Hardcoding these values is an obvious anti-pattern...
2. On older devices the sensors are slow and inaccurate "per se", thus
   the timings should be lowered which is not possible because the
   values are simply inaccessible from the outside.

Signed-off-by: iusmac <iusico.maxim@libero.it>