### PR TITLE
settings: Use SystemSettingListPreference for status bar logo style

### DIFF
--- a/res/values/cr_arrays.xml
+++ b/res/values/cr_arrays.xml
@@ -676,6 +676,73 @@
         <item>1</item>
     </string-array>
 
+    <!-- Custom logo style -->
+    <string-array name="status_bar_logo_style_entries" translatable="false">
+        <item>@string/status_bar_logo_style_crdroid</item>
+        <item>@string/status_bar_logo_style_android</item>
+        <item>@string/status_bar_logo_style_adidas</item>
+        <item>@string/status_bar_logo_style_alien</item>
+        <item>@string/status_bar_logo_style_apple</item>
+        <item>@string/status_bar_logo_style_avengers</item>
+        <item>@string/status_bar_logo_style_batman</item>
+        <item>@string/status_bar_logo_style_batman_tdk</item>
+        <item>@string/status_bar_logo_style_beats</item>
+        <item>@string/status_bar_logo_style_biohazard</item>
+        <item>@string/status_bar_logo_style_blackberry</item>
+        <item>@string/status_bar_logo_style_cannabis</item>
+        <item>@string/status_bar_logo_style_emoticon_cool</item>
+        <item>@string/status_bar_logo_style_emoticon_devil</item>
+        <item>@string/status_bar_logo_style_fire</item>
+        <item>@string/status_bar_logo_style_heart</item>
+        <item>@string/status_bar_logo_style_nike</item>
+        <item>@string/status_bar_logo_style_pacman</item>
+        <item>@string/status_bar_logo_style_puma</item>
+        <item>@string/status_bar_logo_style_rog</item>
+        <item>@string/status_bar_logo_style_spiderman</item>
+        <item>@string/status_bar_logo_style_superman</item>
+        <item>@string/status_bar_logo_style_windows</item>
+        <item>@string/status_bar_logo_style_xbox</item>
+        <item>@string/status_bar_logo_style_ghost</item>
+        <item>@string/status_bar_logo_style_ninja</item>
+        <item>@string/status_bar_logo_style_robot</item>
+        <item>@string/status_bar_logo_style_ironman</item>
+        <item>@string/status_bar_logo_style_captain_america</item>
+        <item>@string/status_bar_logo_style_flash</item>
+    </string-array>
+
+    <string-array name="status_bar_logo_style_values" translatable="false">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+        <item>13</item>
+        <item>14</item>
+        <item>15</item>
+        <item>16</item>
+        <item>17</item>
+        <item>18</item>
+        <item>19</item>
+        <item>20</item>
+        <item>21</item>
+        <item>22</item>
+        <item>23</item>
+        <item>24</item>
+        <item>25</item>
+        <item>26</item>
+        <item>27</item>
+        <item>28</item>
+        <item>29</item>
+    </string-array>
+
     <!-- Vibration patterns -->
     <string-array name="vibration_pattern_entries">
         <item>@string/pattern_dzzz_dzzz</item>

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -1104,6 +1104,36 @@
     <string name="status_bar_logo_summary">Display a custom logo on left or right of the status bar</string>
     <string name="status_bar_logo_position_title">Logo position</string>
     <string name="status_bar_logo_style_title">Logo style</string>
+    <string name="status_bar_logo_style_crdroid">CrDroid</string>
+    <string name="status_bar_logo_style_android">Android</string>
+    <string name="status_bar_logo_style_adidas">Adidas</string>
+    <string name="status_bar_logo_style_alien">Alien</string>
+    <string name="status_bar_logo_style_apple">Apple</string>
+    <string name="status_bar_logo_style_avengers">Avengers</string>
+    <string name="status_bar_logo_style_batman">Batman</string>
+    <string name="status_bar_logo_style_batman_tdk">Batman The Dark Knight</string>
+    <string name="status_bar_logo_style_beats">Beats</string>
+    <string name="status_bar_logo_style_biohazard">Biohazard</string>
+    <string name="status_bar_logo_style_blackberry">BlackBerry</string>
+    <string name="status_bar_logo_style_cannabis">Cannabis</string>
+    <string name="status_bar_logo_style_emoticon_cool">Emoticon cool</string>
+    <string name="status_bar_logo_style_emoticon_devil">Emoticon devil</string>
+    <string name="status_bar_logo_style_fire">Fire</string>
+    <string name="status_bar_logo_style_heart">Heart</string>
+    <string name="status_bar_logo_style_nike">Nike</string>
+    <string name="status_bar_logo_style_pacman">Pac-man</string>
+    <string name="status_bar_logo_style_puma">Puma</string>
+    <string name="status_bar_logo_style_rog">ROG</string>
+    <string name="status_bar_logo_style_spiderman">Spider-Man</string>
+    <string name="status_bar_logo_style_superman">Superman</string>
+    <string name="status_bar_logo_style_windows">Windows</string>
+    <string name="status_bar_logo_style_xbox">Xbox</string>
+    <string name="status_bar_logo_style_ghost">Ghost</string>
+    <string name="status_bar_logo_style_ninja">Ninja</string>
+    <string name="status_bar_logo_style_robot">Robot</string>
+    <string name="status_bar_logo_style_ironman">Iron Man</string>
+    <string name="status_bar_logo_style_captain_america">Captain America</string>
+    <string name="status_bar_logo_style_flash">Flash</string>
 
     <!-- APK details on App info screen -->
     <string name="app_info_install_time">Installed: %1$s</string>

--- a/res/xml/crdroid_settings_statusbar.xml
+++ b/res/xml/crdroid_settings_statusbar.xml
@@ -151,14 +151,13 @@
             android:defaultValue="0"
             android:dependency="status_bar_logo" />
 
-        <com.crdroid.settings.preferences.SystemSettingSeekBarPreference
+        <com.crdroid.settings.preferences.SystemSettingListPreference
             android:key="status_bar_logo_style"
             android:icon="@drawable/ic_tag"
             android:title="@string/status_bar_logo_style_title"
+            android:entries="@array/status_bar_logo_style_entries"
+            android:entryValues="@array/status_bar_logo_style_values"
             android:defaultValue="0"
-            settings:interval="1"
-            android:max="29"
-            android:min="0"
             android:dependency="status_bar_logo" />
 
     </PreferenceCategory>


### PR DESCRIPTION
SystemSettingSeekBarPreference doesn't really fit here because we can't see which logo we're selecting and it's not convenient to use when there are so many options, so we change it to SystemSettingListPreference so we can see the list of logos and choose from it easily.